### PR TITLE
Add Shiro 白 – Steam One-Click Login Client

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,7 +13,7 @@ from typing import Any
 from urllib.parse import quote, urlencode
 
 import httpx
-from fastapi import Depends, FastAPI, Header, HTTPException, Query, status
+from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.responses import RedirectResponse
@@ -1383,6 +1383,7 @@ def _cleanup_expired_shiro_tokens() -> None:
 @app.post("/accounts/{account_id}/shiro-login")
 async def shiro_login(
     account_id: int,
+    request: Request,
     actor: User = Depends(resolve_actor),
     db: Session = Depends(get_db),
 ):
@@ -1409,8 +1410,9 @@ async def shiro_login(
         "created_at": time.time(),
     }
 
-    # Build the protocol URL with URL-encoded API base.
-    api_base = quote("http://localhost:3000", safe="")
+    # Derive API base URL from the incoming request so it works in any
+    # environment (local dev, Docker, behind reverse proxy, etc.).
+    api_base = quote(str(request.base_url).rstrip("/"), safe="")
     launch_url = f"shiro://login?token={token}&api={api_base}"
 
     return {"token": token, "launch_url": launch_url}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,6 +81,9 @@ class Settings(BaseSettings):
     steam_status_refresh_seconds: int = 30
     steam_id_legacy_cleanup_enabled: bool = False
 
+    # Shiro one-time token TTL (seconds).
+    shiro_token_ttl: int = 30
+
 
 @lru_cache
 def get_settings() -> Settings:
@@ -1359,6 +1362,74 @@ def delete_account(
 
     db.delete(account)
     db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Shiro one-time token endpoints (Steam one-click login)
+# ---------------------------------------------------------------------------
+
+# In-memory store for one-time Shiro tokens: token → {account_name, password, created_at}
+_shiro_tokens: dict[str, dict[str, Any]] = {}
+
+
+def _cleanup_expired_shiro_tokens() -> None:
+    """Remove Shiro tokens older than the configured TTL."""
+    now = time.time()
+    expired = [t for t, v in _shiro_tokens.items() if now - v["created_at"] > settings.shiro_token_ttl]
+    for t in expired:
+        del _shiro_tokens[t]
+
+
+@app.post("/accounts/{account_id}/shiro-login")
+async def shiro_login(
+    account_id: int,
+    actor: User = Depends(resolve_actor),
+    db: Session = Depends(get_db),
+):
+    """Create a one-time token for Shiro to fetch credentials.
+
+    Returns {token, launch_url} – the frontend opens the launch_url
+    which triggers the shiro:// protocol handler on the user's machine.
+    """
+    account = db.get(SteamAccount, account_id)
+    if not account:
+        raise HTTPException(status_code=404, detail="Account not found")
+
+    plaintext_password = decrypt_account_password(account.password, settings.app_secret)
+
+    # Cleanup expired tokens before creating a new one.
+    _cleanup_expired_shiro_tokens()
+
+    # Create a cryptographically random one-time token.
+    token = secrets.token_urlsafe(32)
+    _shiro_tokens[token] = {
+        "account_name": account.username,
+        "password": plaintext_password,
+        "persona_name": account.steam_profile_name or account.username,
+        "created_at": time.time(),
+    }
+
+    # Build the protocol URL with URL-encoded API base.
+    api_base = quote("http://localhost:3000", safe="")
+    launch_url = f"shiro://login?token={token}&api={api_base}"
+
+    return {"token": token, "launch_url": launch_url}
+
+
+@app.get("/shiro/credentials/{token}")
+async def shiro_credentials(token: str):
+    """Exchange a one-time token for account credentials.
+
+    This endpoint requires no authentication – the token itself IS the auth.
+    The token is deleted immediately after use (single-use).
+    """
+    _cleanup_expired_shiro_tokens()
+
+    creds = _shiro_tokens.pop(token, None)
+    if not creds:
+        raise HTTPException(status_code=404, detail="Token not found or expired")
+
+    return {"account_name": creds["account_name"], "password": creds["password"], "persona_name": creds.get("persona_name", creds["account_name"])}
 
 
 def register_frontend_routes() -> None:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -248,6 +248,11 @@ function App() {
   const [massImportPublic, setMassImportPublic] = useState(false);
   const [massImportResult, setMassImportResult] = useState<MassImportResponse | null>(null);
   const [isImporting, setIsImporting] = useState(false);
+
+  // Shiro (Steam one-click login) state
+  const [shiroLoginAccount, setShiroLoginAccount] = useState<Account | null>(null);
+  const [shiroLoading, setShiroLoading] = useState(false);
+  const [shiroMessage, setShiroMessage] = useState("");
   const [showManagementTools, setShowManagementTools] = useState(false);
   const [allowInviteLinkCreation, setAllowInviteLinkCreation] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -1578,10 +1583,61 @@ function App() {
     );
   };
 
+  const handleShiroLogin = async (account: Account) => {
+    setShiroLoginAccount(account);
+    setShiroLoading(true);
+    setShiroMessage("Launching Shiro...");
+
+    try {
+      const resp = await apiFetch<{
+        token: string;
+        launch_url: string;
+      }>(`/accounts/${account.id}/shiro-login`, token, { method: "POST" });
+
+      // Open the shiro:// protocol URL via a hidden iframe (doesn't navigate away).
+      const iframe = document.createElement("iframe");
+      iframe.style.display = "none";
+      iframe.src = resp.launch_url;
+      document.body.appendChild(iframe);
+      setTimeout(() => iframe.remove(), 2000);
+
+      setShiroMessage("Shiro is handling the login – check the Shiro window.");
+      showUiNotice(`Shiro launched for ${account.username}`);
+
+      // Auto-dismiss after a few seconds.
+      setTimeout(() => {
+        setShiroLoginAccount(null);
+        setShiroLoading(false);
+        setShiroMessage("");
+      }, 4000);
+    } catch (err) {
+      setShiroMessage(err instanceof Error ? err.message : "Failed to launch Shiro");
+      setShiroLoading(false);
+      setTimeout(() => {
+        setShiroLoginAccount(null);
+        setShiroMessage("");
+      }, 3000);
+    }
+  };
+
+  const closeShiroModal = () => {
+    setShiroLoginAccount(null);
+    setShiroLoading(false);
+    setShiroMessage("");
+  };
+
   const renderAccountActions = (account: Account, compact = false) => {
     if (currentUserId === account.owner_id) {
       return (
         <div className={`flex ${compact ? "flex-wrap" : ""} gap-1.5`}>
+          <button
+            type="button"
+            className="inline-flex items-center rounded-lg border border-emerald-300/40 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-100 hover:bg-emerald-500/20"
+            title="Login to this Steam account via Shiro"
+            onClick={() => handleShiroLogin(account)}
+          >
+            ▶ Login
+          </button>
           <button
             type="button"
             className="inline-flex items-center rounded-lg border border-sky-300/40 bg-sky-500/10 px-2 py-1 text-[11px] text-sky-100 hover:bg-sky-500/20"
@@ -2680,6 +2736,33 @@ function App() {
                 ))}
               </div>
             )}
+          </div>
+        </div>
+      )}
+
+      {/* Shiro Steam Login Modal */}
+      {shiroLoginAccount && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/80 backdrop-blur-sm px-4">
+          <div className="anime-panel w-full max-w-sm rounded-3xl p-6 space-y-4">
+            <div className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold text-zinc-100">
+                Steam Login – {shiroLoginAccount.username}
+              </h2>
+              <button
+                type="button"
+                className="rounded-lg border border-zinc-600 px-3 py-1 text-sm text-zinc-300 hover:bg-zinc-700/60"
+                onClick={closeShiroModal}
+              >
+                ✕
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3">
+              {shiroLoading && (
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-emerald-400 border-t-transparent" />
+              )}
+              <p className="text-sm text-zinc-300">{shiroMessage}</p>
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
##  Shiro 白 – Steam One-Click Login Client

Shiro is a lightweight Electron companion app that handles the client-side Steam login flow triggered by Kuroi.

### What it does
- Receives `shiro://` protocol URLs from Kuroi with a one-time credential token
- Authenticates via `steam-session` (supports Email, TOTP & device confirmation)
- Logs in via **CEF Remote Debugging** (`SteamClient.Auth.SetLoginToken()`) – no VDF file patching needed
- Falls back to **encrypted VDF injection** if CEF is unavailable
- Atomic writes, backup/restore on failure, secure wipe of temp files

**Stack:** Electron, steam-session, Chrome DevTools Protocol via WebSocket

**Security:** Credentials are memory-only, tokens are single-use, context isolation + CSP enforced, backup dirs restricted to `0700`.